### PR TITLE
Plugin name in lowerCamelCase for web and in the example app

### DIFF
--- a/generators/app/templates/examples/index.vue
+++ b/generators/app/templates/examples/index.vue
@@ -13,7 +13,7 @@
 
 <script>
 
-	const plugin = weex.requireModule('<%= upperCamelCaseName %>');
+	const plugin = weex.requireModule('<%= lowerCamelCaseName %>');
 	module.exports = {
 		data: {
 			value: '',

--- a/generators/app/templates/js/src/index.js
+++ b/generators/app/templates/js/src/index.js
@@ -13,7 +13,7 @@ const meta = {
 };
 
 function init(weex) {
-  weex.registerModule('<%= upperCamelCaseName %>', <%= upperCamelCaseName %>, meta);
+  weex.registerModule('<%= lowerCamelCaseName %>', <%= upperCamelCaseName %>, meta);
 }
 
 export default {


### PR DESCRIPTION
On Android and iOS the plugin exported in lowerCamelCase (ex. weexMyPlugin), but the web version was in UpperCamelCase (ex. WeexMyPlugin).

The example app (`examples/index.vue`) app was also importing with UpperCamelCase, and as a result the playground app in iOS and Android didn't work right out of the box.

This PR uniformizes the plugin name to lowerCamelCase, as I see that is the rule for most plugins that are out there.