### PR TITLE
Improve boilerplate docs.

### DIFF
--- a/generators/app/templates/README.cn.md
+++ b/generators/app/templates/README.cn.md
@@ -1,0 +1,63 @@
+# <%= projectName %>
+<%= projectName %>是一个weex插件，可以通过weexpack快速集成，可以丰富weex功能
+
+支持的WeexSDK版本： >= <%= WeexSDKVersion %>
+
+# 功能
+
+# 快速使用
+- 通过weexpack初始化一个测试工程 weextest
+   ```
+   weex create weextest
+   ```
+- 添加ios平台
+  ```
+  weex platform add ios
+  ```
+- 添加android平台
+  ```
+  weex platform add android
+  ```
+- 添加插件
+  ```
+  weex plugin add <%= projectName %>
+  ```
+# 项目地址
+[github](please add you source code address)
+
+# 已有工程集成
+## iOS集成插件<%= iOSProjectName %>
+- 命令行集成
+  ```
+  weex plugin add <%= projectName %>
+  ```
+- 手动集成
+  在podfile 中添加
+  ```
+  pod '<%= iOSProjectName %>'
+  ```
+
+## 安卓集成插件<%= AndroidProjectName %>
+- 命令行集成
+  ```
+  weexpack plugin add <%= projectName %>
+  ```
+- 手动集成
+  在相应工程的build.gradle文件的dependencies中添加
+  ```
+  compile '${groupId}:<%= AndroidProjectName %>:{$version}'
+  ``` 
+  注意：您需要自行指定插件的groupId和version并将构建产物发布到相应的依赖管理仓库内去（例如maven）, 您也可以对插件的name进行自定义，默认将使用插件工程的名称作为name
+
+
+## 浏览器端集成 <%= projectName %>
+- 命令行集成
+  ```
+  npm install  <%= projectName %>
+  ```
+- 手动集成
+  在相应工程的package.json文件的dependencies中添加
+  ```
+  <%= projectName %>:{$version}'
+  ``` 
+  

--- a/generators/app/templates/README.md
+++ b/generators/app/templates/README.md
@@ -1,63 +1,34 @@
 # <%= projectName %>
-<%= projectName %>是一个weex插件，可以通过weexpack快速集成，可以丰富weex功能
+<%= projectName %> is a weex plugin that can easily be integrated with `weexpack` to extend weex functionality.
 
-支持的WeexSDK版本： >= <%= WeexSDKVersion %>
+## Installing the plugin in your project
+### Using `weexpack`:
+```
+weex plugin add <%= projectName %>
+```
 
-# 功能
+### Manual integration:
+#### iOS:
+```
+pod '<%= iOSProjectName %>'
+```
 
-# 快速使用
-- 通过weexpack初始化一个测试工程 weextest
-   ```
-   weex create weextest
-   ```
-- 添加ios平台
-  ```
-  weex platform add ios
-  ```
-- 添加android平台
-  ```
-  weex platform add android
-  ```
-- 添加插件
-  ```
-  weex plugin add <%= projectName %>
-  ```
-# 项目地址
-[github](please add you source code address)
+#### Android:
+Add the following line to the dependencies list in the build.gradle file for the corresponding project.
+```
+ compile '${groupId}:<%= AndroidProjectName %>:{$version}'
+```
+> Note: You need to specify the groupId and $version of the project.
 
-# 已有工程集成
-## iOS集成插件<%= iOSProjectName %>
-- 命令行集成
-  ```
-  weex plugin add <%= projectName %>
-  ```
-- 手动集成
-  在podfile 中添加
-  ```
-  pod '<%= iOSProjectName %>'
-  ```
+#### Web integration
+```
+ npm install <%= projectName %>
+```
 
-## 安卓集成插件<%= AndroidProjectName %>
-- 命令行集成
-  ```
-  weexpack plugin add <%= projectName %>
-  ```
-- 手动集成
-  在相应工程的build.gradle文件的dependencies中添加
-  ```
-  compile '${groupId}:<%= AndroidProjectName %>:{$version}'
-  ``` 
-  注意：您需要自行指定插件的groupId和version并将构建产物发布到相应的依赖管理仓库内去（例如maven）, 您也可以对插件的name进行自定义，默认将使用插件工程的名称作为name
+## Developing the plugin
 
+See [How to develop](./doc/how-to-develop.md).
 
-## 浏览器端集成 <%= projectName %>
-- 命令行集成
-  ```
-  npm install  <%= projectName %>
-  ```
-- 手动集成
-  在相应工程的package.json文件的dependencies中添加
-  ```
-  <%= projectName %>:{$version}'
-  ``` 
-  
+also,
+
+See the [Plugin Development Guide](https://weex.apache.org/guide/create-a-plugin.html).

--- a/generators/app/templates/doc/how-to-develop.cn.md
+++ b/generators/app/templates/doc/how-to-develop.cn.md
@@ -1,0 +1,82 @@
+# weex 插件开发套件
+- weex 插件开发套件旨在帮助用户快速，方便开发插件，一键集成，无需更改任何业务代码
+
+## iOS
+
+### 如何开发插件
+- 通过weex初始化一个<%= iOSProjectName %>工程
+   ```
+   weex create dev <%= iOSProjectName %>
+   ```
+- 工程目录如下
+    ```
+     ├── android(Android插件工程)
+     │    ├── buid.gradle(android发布文件)
+     ├── ios(ios插件工程)
+     ├── js(h5插件工程)
+     ├── example(例子,开发者用来测试问题)
+     │    ├── android(demo)
+     │    ├── ios(demo)
+     │    ├── js(demo)
+     │    └── index.we
+     ├── ****.podspec(ios发布文件)
+     ├── start(weex编译命令)
+     ├── package.json(js发布文件)
+     ├── README.md
+   ```
+- 请在ios目录下用如下命令初始化ios工程
+```
+pod update
+```
+- 添加插件初测信息
+   - component示例
+   ```
+   WX_PlUGIN_EXPORT_MODULE(test, WPTestComponent)
+   ```
+   - module示例
+   ```
+   WX_PlUGIN_EXPORT_COMPONENT(test, WPTestModule)
+   ```
+   - Handler示例
+   ```
+   WX_PlUGIN_EXPORT_HANDLER(WPTestHandler, WXImgLoaderProtocol)
+   ```
+- 插件开发完成请在example/ios测试
+   - 初始化测试工程
+   ```
+   pod update
+   ```
+   - 检验测试结果,demo运行起来会在控制台输入下面类似信息
+   ```
+   2017-03-24 16:54:52.934 WeexDemo[88059:2693902] WPTestComponent register
+   2017-03-24 16:54:52.936 WeexDemo[88059:2693902] WXImgLoaderProtocol register
+   2017-03-24 16:54:52.937 WeexDemo[88059:2693902] WPTestModule register
+   ```
+
+### 如何发布插件
+- 发布插件到cocoapods 仓库
+   - 已经默认创建好podspec，开发者在根目录通过如下命令检查iOS插件的正确性
+  ```
+  pod spec lint --allow-warnings
+  ```
+   - 发布插件到cocoapods 仓库
+   ```
+   pod trunk push --allow-warnings
+   ```
+
+### 如何发布插件到weex market
+- 通过weex命令发布
+```
+weex plugin publish
+```
+
+### 如何集成插件<%= iOSProjectName %>
+- 命令行集成
+  ```
+  weex plugin add <%= iOSProjectName %>
+  ```
+- 手动集成
+  在podfile 中添加
+  ```
+  pod '<%= iOSProjectName %>'
+  ```

--- a/generators/app/templates/doc/how-to-develop.md
+++ b/generators/app/templates/doc/how-to-develop.md
@@ -1,82 +1,108 @@
-# weex 插件开发套件
-- weex 插件开发套件旨在帮助用户快速，方便开发插件，一键集成，无需更改任何业务代码
+# Plugin Development Guide
+
+## Getting started
+
+1- Clone the project
+  ```
+  git clone https://github.com/<me>/<%= projectName %>
+  ```
+
+2- Install dependencies
+  ```
+  npm install -g weex-toolkit
+  weex update weex-devtool@latest
+  npm install
+  ```
+  For more detail, see [Setup Development Environment](https://weex.apache.org/guide/set-up-env.html).
+
+## Project structure
+
+The project structure is:
+```
+     ├── android   (Android native code project)
+     │    └── ...
+     ├── ios   (iOS native code project)
+     │    └── ...
+     ├── js   (html5 project)
+     │    └── ...
+     ├── examples   (sample app)
+     │    └── index.vue
+     ├── playground   (sample projects to test the plugin)
+     │    ├── android
+     │    ├── browser
+     │    └── ios
+     ├── <%= iOSProjectName %>.podspec   (iOS .podspec)
+     ├── package.json
+     ├── README.md
+  ```
+
+The `examples` directory contains a weex app that you can use to test your plugin. This test app will be loaded from the playground apps that are installed in the `playground` folder.
+
+## Web
+
+### Developing and testing with the playground app
+1. Build the example weex app in `examples/index.vue`:
+  ```
+
+  ```
+  Webpack will be listening for changes in `examples/index.vue` and re-build the example app for you. The app will be served in the port 12580 (e.g. http://localhost:12580).
+
+2. Edit the plugin JavaScript/HTML/CSS code under the `js` folder. Refresh the test app to update the plugin in the playground app.
+
+### Extending Web functionality
+See [Extend Web Render](https://weex.apache.org/guide/guide/extend-web-render.html).
+
+## Android
+
+### Developing and testing with the playground app
+1. Build the example weex app in `examples/index.vue`:
+  ```
+  npm run start:native
+  ```
+  Webpack will be listening for changes in `examples/index.vue` and re-build the example app for you.
+
+2. Open the android project under `playground/android` with Android Studio.
+
+  The native plugin code will be linked as a gradle dependency. You can develop and test the plugin directly from Android Studio. You can also use `weex debug` to debug the playground app.
+
+### Extending native functionality
+See [Extend Android](https://weex.apache.org/guide/extend-android.html).
 
 ## iOS
 
-### 如何开发插件
-- 通过weex初始化一个<%= iOSProjectName %>工程
-   ```
-   weex create dev <%= iOSProjectName %>
-   ```
-- 工程目录如下
-    ```
-     ├── android(Android插件工程)
-     │    ├── buid.gradle(android发布文件)
-     ├── ios(ios插件工程)
-     ├── js(h5插件工程)
-     ├── example(例子,开发者用来测试问题)
-     │    ├── android(demo)
-     │    ├── ios(demo)
-     │    ├── js(demo)
-     │    └── index.we
-     ├── ****.podspec(ios发布文件)
-     ├── start(weex编译命令)
-     ├── package.json(js发布文件)
-     ├── README.md
-   ```
-- 请在ios目录下用如下命令初始化ios工程
-```
-pod update
-```
-- 添加插件初测信息
-   - component示例
-   ```
-   WX_PlUGIN_EXPORT_MODULE(test, WPTestComponent)
-   ```
-   - module示例
-   ```
-   WX_PlUGIN_EXPORT_COMPONENT(test, WPTestModule)
-   ```
-   - Handler示例
-   ```
-   WX_PlUGIN_EXPORT_HANDLER(WPTestHandler, WXImgLoaderProtocol)
-   ```
-- 插件开发完成请在example/ios测试
-   - 初始化测试工程
-   ```
-   pod update
-   ```
-   - 检验测试结果,demo运行起来会在控制台输入下面类似信息
-   ```
-   2017-03-24 16:54:52.934 WeexDemo[88059:2693902] WPTestComponent register
-   2017-03-24 16:54:52.936 WeexDemo[88059:2693902] WXImgLoaderProtocol register
-   2017-03-24 16:54:52.937 WeexDemo[88059:2693902] WPTestModule register
-   ```
+### Developing and testing with the playground app
+1. Build the example weex app in `examples/index.vue`:
+  ```
+  npm run start:native
+  ```
+  Webpack will be listening for changes in `examples/index.vue` and re-build the example app for you.
 
-### 如何发布插件
-- 发布插件到cocoapods 仓库
-   - 已经默认创建好podspec，开发者在根目录通过如下命令检查iOS插件的正确性
+2. Open the iOS playground app and install the dependencies:
+  ```
+  cd playground/ios
+  pod install
+  ```
+3. Open `WeexDemo.xcworkspace` in Xcode.
+
+  The native plugin code will be linked as cocoa pod. You can develop and test the plugin directly from Xcode. You can also use `weex debug` to debug the playground app.
+
+### Extending native functionality
+See [Extend iOS](https://weex.apache.org/guide/extend-ios.html).
+
+### Publishing the plugin to the cocapods repository
+1. Edit the `<%= iOSProjectName %>.podspec` generated in the root of the plugin project.
+2. Check the correctness of the iOS plugin:
   ```
   pod spec lint --allow-warnings
   ```
-   - 发布插件到cocoapods 仓库
-   ```
-   pod trunk push --allow-warnings
-   ```
+3. Publish to cocoapods repository:
+  ```
+  pod trunk push --allow-warnings
+  ```
 
-### 如何发布插件到weex market
-- 通过weex命令发布
+## Publish the plugin in the weex market
+You can publish to the [Weex Market](https://weex.apache.org/tools/market.html) with the simple command:
 ```
 weex plugin publish
 ```
 
-### 如何集成插件<%= iOSProjectName %>
-- 命令行集成
-  ```
-  weex plugin add <%= iOSProjectName %>
-  ```
-- 手动集成
-  在podfile 中添加
-  ```
-  pod '<%= iOSProjectName %>'
-  ```


### PR DESCRIPTION
As suggested briefly in the [mailing list](http://mail-archives.apache.org/mod_mbox/incubator-weex-dev/201711.mbox/%3cCADXNVOpgP9SmCAcbcJZqWOtVrc0GmKS+df2_ryOCNWm3oP05iQ@mail.gmail.com%3e), the generated plugin boilerplate should generate documentation more adequate for the final plugin project result. With this in mind, this PR proposes:

- ` generators/app/templates/README.md` will be the front page of the plugin in the repo, so it has instructions to the final user of the plugin, i.e. someone who wants to use the plugin in his weex project. 

- ` generators/app/templates/doc/how-to-develop.md` will have instructions for the developer of the plugin, e.g. a team member or someone who wants to fix/improve the plugin. So this page will have instructions on how to set the environment, develop and test the plugin.

- The instructions on how to create the plugin will only exist on the weex documentation site. The new docs already have [a page for that](https://github.com/apache/incubator-weex-site/blob/master/source/guide/create-a-plugin.md).

I only wrote the English version of the docs. The previous docs were renamed to `.cn.md`. Translation is needed.

The links to the documentation refers to the **new** page that should be published any time now.